### PR TITLE
fix(speedtest-cli): avoid speedtest DNS error

### DIFF
--- a/apps/api/src/static-info.ts
+++ b/apps/api/src/static-info.ts
@@ -308,7 +308,7 @@ export const runSpeedTest = async (): Promise<string> => {
     });
   } else if (await commandExists('speedtest-cli')) {
     usedRunner = 'speedtest-cli';
-    const { stdout } = await exec('speedtest-cli --json');
+    const { stdout } = await exec('speedtest-cli --json --secure');
     const json = JSON.parse(stdout);
 
     STATIC_INFO.next({


### PR DESCRIPTION
**Description**

Avoid intermitten 403 Forbidden error caused by speedtest DNS by using --secure switch.

**Related Issue(s)**

None on this repo. 
