### PR TITLE
Fixes 100% cpu usage on windows platform.

### DIFF
--- a/apps/server/src/data/gpu.ts
+++ b/apps/server/src/data/gpu.ts
@@ -13,12 +13,18 @@ const normalizeGpuModel = (model: string) => {
   return model ? model.replace(/\[.*\]/gi, '').trim() : undefined;
 };
 
+const isValidController = (controller: si.Systeminformation.GraphicsControllerData) => {
+  const blacklist = ['monitor'];
+  const model = controller.model.toLowerCase();
+  return blacklist.every( w => ! model.includes(w) );
+};
+
 export default {
   dynamic: async (): Promise<GpuLoad> => {
     const gpuInfo = await si.graphics();
 
     return {
-      layout: gpuInfo.controllers.map(controller => ({
+      layout: gpuInfo.controllers.filter(isValidController).map(controller => ({
         load: controller.utilizationGpu ?? 0,
         memory: controller.utilizationMemory ?? 0,
       })),
@@ -28,7 +34,7 @@ export default {
     const gpuInfo = await si.graphics();
 
     return {
-      layout: gpuInfo.controllers.map(controller => ({
+      layout: gpuInfo.controllers.filter(isValidController).map(controller => ({
         brand: normalizeGpuBrand(controller.vendor),
         model:
           normalizeGpuName(controller.name) ??

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -17,7 +17,7 @@ import { CONFIG } from './config';
 import getNetworkInfo from './data/network';
 import { getDynamicServerInfo } from './dynamic-info';
 import { environment } from './environments/environment';
-import { setupNetworking, setupOsVersion } from './setup';
+import { setupNetworking, setupOsVersion, setupHostSpecific, tearDownHostSpecific } from './setup';
 import {
   getStaticServerInfo,
   getStaticServerInfoObs,
@@ -91,6 +91,7 @@ if (!CONFIG.disable_integrations) {
 server.listen(CONFIG.port, async () => {
   console.log('listening on *:' + CONFIG.port);
 
+  await setupHostSpecific();
   await setupNetworking();
   await setupOsVersion();
   await loadStaticServerInfo();
@@ -190,10 +191,12 @@ server.on('error', console.error);
 
 process.on('uncaughtException', e => {
   console.error(e);
+  tearDownHostSpecific();
   process.exit(1);
 });
 
 process.on('unhandledRejection', e => {
   console.error(e);
+  tearDownHostSpecific();
   process.exit(1);
 });

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -1,7 +1,9 @@
 import { exec as exaca } from 'child_process';
 import * as fs from 'fs';
+import * as si from 'systeminformation';
 import { promisify } from 'util';
 import { CONFIG } from './config';
+import { platformIsWindows } from './utils';
 
 const exec = promisify(exaca);
 
@@ -98,5 +100,19 @@ export const setupOsVersion = async () => {
     }
   } catch (e) {
     console.warn(e);
+  }
+};
+
+export const setupHostSpecific = async () => {
+  if (platformIsWindows) {
+    console.log('Acquiring Windows Persistent Powershell')
+    si.powerShellStart()
+  }
+};
+
+export const tearDownHostSpecific = () => {
+  if (platformIsWindows) {
+    console.log('Releasing Windows Persistent Powershell')
+    si.powerShellRelease()
   }
 };


### PR DESCRIPTION
**Description**

Due to how `systeminformation` spawns `powershell` processes to gather informations, cpu usage can go crazy on Windows.
When pooling for these infos, one should first call an init procedure to share a single shell, thus saving cpu resources.

See: https://github.com/sebhildebrandt/systeminformation/issues/616

Also, add small feature to allow keyword based blacklisting of gpu model (to remove unwanted monitor being detected as gpu).


**Related Issue(s)**
#940 
