### PR TITLE
fix: dynamic storage info slow on windows

### DIFF
--- a/apps/server/src/data/storage/dynamic.ts
+++ b/apps/server/src/data/storage/dynamic.ts
@@ -131,7 +131,7 @@ export class DynamicStorageMapper {
 
 export default async (): Promise<StorageLoad> => {
   const svInfo = getStaticServerInfo();
-  const [blocks, sizes] = await Promise.all([si.blockDevices(), si.fsSize()]);
+  const [sizes, blocks] = await Promise.all([si.fsSize(), si.blockDevices()]);
 
   return new DynamicStorageMapper(
     PLATFORM_IS_WINDOWS,


### PR DESCRIPTION
For some reason I can't explain, the original order of fetching system information is slow using the Promise.all gathering method as opposed to two sequential awaits...

The reversed order does not suffer from this performance issue though...

**Description**

<!-- Please write a short description of what your PR does here -->

**Related Issue(s)**

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
<!-- e.g. #312 -->
