### PR TITLE
Fix missing backslash

### DIFF
--- a/apps/docs/docs/installation/docker.mdx
+++ b/apps/docs/docs/installation/docker.mdx
@@ -39,6 +39,6 @@ docker container run -it \
   -v /:/mnt/host:ro \
   --privileged \
   --gpus all \
-  --env DASHDOT_WIDGET_LIST="os,cpu,storage,ram,network,gpu"
+  --env DASHDOT_WIDGET_LIST="os,cpu,storage,ram,network,gpu" \
   mauricenino/dashdot:nvidia
 ```


### PR DESCRIPTION
**Description**
Change GPU support command from
```
docker container run -it \
  -p 80:3001 \
  -v /:/mnt/host:ro \
  --privileged \
  --gpus all \
  --env DASHDOT_WIDGET_LIST="os,cpu,storage,ram,network,gpu"
  mauricenino/dashdot:nvidia
  ```
  
  To
  ```
  docker container run -it \
  -p 80:3001 \
  -v /:/mnt/host:ro \
  --privileged \
  --gpus all \
  --env DASHDOT_WIDGET_LIST="os,cpu,storage,ram,network,gpu" \  # Added Backslash here
  mauricenino/dashdot:nvidia
  ```
  
<!-- Please write a short description of what your PR does here -->

**Related Issue(s)**
Docker installation documentations
