### PR TITLE
fix: install coreutils in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
     lsblk \
     mdadm \
     dmidecode \
+    coreutils \
     util-linux \
     lm-sensors \
     speedtest-cli &&\


### PR DESCRIPTION
**Description**

Install the `coreutils` package into the `Dockerfile` base image to fix the `df -l` option as explained [here](https://github.com/sebhildebrandt/systeminformation/issues/885#issuecomment-2103815330).

**Related Issue(s)**

- https://github.com/MauriceNino/dashdot/issues/944
- https://github.com/MauriceNino/dashdot/issues/1032
- https://github.com/sebhildebrandt/systeminformation/issues/885