### PR TITLE
fix dead Homarr docs link

### DIFF
--- a/apps/docs/docs/integration/index.mdx
+++ b/apps/docs/docs/integration/index.mdx
@@ -19,7 +19,7 @@ tags:
 
 Website: [https://homarr.dev](https://homarr.dev)
 
-1. Install and setup Homarr [according to the docs](https://homarr.dev/docs/introduction/installation)
+1. Install and setup Homarr [according to the docs](https://homarr.dev/docs/getting-started/)
 2. Enter the edit mode
 3. Add the Dash. widget from the header menu
 4. Drag your widget to your desired location on the dashboard


### PR DESCRIPTION
**Description**

Replaces a dead hyperlink with the correct one for Homarr's installation guide.

**Related Issue(s)**

None afaik.
