### PR TITLE
Add Debian Logo

### DIFF
--- a/apps/view/src/widgets/server.tsx
+++ b/apps/view/src/widgets/server.tsx
@@ -2,6 +2,7 @@ import { Config, OsInfo, Transient } from '@dash/common';
 import {
   faApple,
   faCentos,
+  faDebian,
   faFedora,
   faGithub,
   faLinux,
@@ -121,6 +122,8 @@ const ServerIcon: FC<{ os: string } & Omit<FontAwesomeIconProps, 'icon'>> = ({
 
   if (os.includes('ubuntu')) {
     icon = faUbuntu;
+  } else if (os.includes('debian')){
+    icon = faDebian
   } else if (os.includes('suse')) {
     icon = faSuse;
   } else if (os.includes('redhat')) {


### PR DESCRIPTION
**Description**

Simple update to server.tsx to add the Debian-Logo to the Dashboard. I always thought it was a bit sad that Debian was missing since it is still one of the most widely used distros
![Preview](https://github.com/user-attachments/assets/4f9ebbf5-8775-4b0b-b2ae-f24ae74d55a0)

