### PR TITLE
fix: Container OS reported instead of Host OS

### DIFF
--- a/apps/server/src/data/os.ts
+++ b/apps/server/src/data/os.ts
@@ -2,11 +2,17 @@ import { OsInfo } from '@dash/common';
 import { exec } from 'child_process';
 import * as si from 'systeminformation';
 import { promisify } from 'util';
+import { refreshHostOsRelease } from '../utils';
 
 const execp = promisify(exec);
 
 export default {
   static: async (): Promise<OsInfo> => {
+    try {
+      await refreshHostOsRelease();
+    } catch (err) {
+      console.warn('Cannot refresh /etc/os-release (os results may be outdated):', err);
+    }
     const osInfo = await si.osInfo();
 
     const buildInfo = JSON.parse(

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -96,7 +96,7 @@ export const setupOsVersion = async () => {
   try {
     if (CONFIG.running_in_docker) {
       console.debug("CONFIG.running_in_docker", CONFIG.running_in_docker)
-      const hostPath = MNT_OS_PATH_CANDIDATES.find(p => fs.existsSync(p));
+      const hostPath = MNT_OS_PATH_CANDIDATES.find(p => fs.lstatSync(p));
       console.debug("hostPath", hostPath)
 
       if (hostPath) {

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -95,32 +95,26 @@ const MNT_OS_PATH_CANDIDATES = [
 export const setupOsVersion = async () => {
   try {
     if (CONFIG.running_in_docker) {
-      console.debug("CONFIG.running_in_docker", CONFIG.running_in_docker)
       const hostPath = MNT_OS_PATH_CANDIDATES.find(p => fs.lstatSync(p));
-      console.debug("hostPath", hostPath)
 
       if (hostPath) {
         await refreshHostOsRelease();
 
-        // const realFile = await resolveSymlink(hostPath);
-        // const arrow = hostPath === realFile ? '' : ` → "${realFile}"`;
+        const realFile = await resolveSymlink(hostPath);
+        const arrow = hostPath === realFile ? '' : ` → "${realFile}"`;
 
-        console.log(`Using host os-release from "${hostPath}"`);
-        // console.log(`Using host os-release from "${hostPath}"${arrow}`);
+        console.log(`Bound "${hostPath}"${arrow} to ${LOCAL_OS_PATHS
+        .filter(p => fs.existsSync(p))
+        .map(p => `"${p}"`)
+        .join(' and ')}`);
         return;
       }
     }
-
-    console.log(
-      `Using os-release from ${LOCAL_OS_PATHS
-        .filter(p => fs.existsSync(p))
-        .map(p => `"${p}"`)
-        .join(' or ')}`
-    );
   } catch (e) {
     console.warn(e);
+  } finally {
     console.log(
-      `Using host os-release from ${LOCAL_OS_PATHS
+      `Using os-release from ${LOCAL_OS_PATHS
         .filter(p => fs.existsSync(p))
         .map(p => `"${p}"`)
         .join(' or ')}`

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as si from 'systeminformation';
 import { promisify } from 'util';
 import { CONFIG } from './config';
-import { PLATFORM_IS_WINDOWS } from './utils';
+import { PLATFORM_IS_WINDOWS, refreshHostOsRelease, resolveSymlink } from './utils';
 
 const exec = promisify(exaca);
 
@@ -87,25 +87,33 @@ export const setupNetworking = async () => {
 };
 
 const LOCAL_OS_PATHS = ['/etc/os-release', '/usr/lib/os-release'];
-const MNT_OS_PATH = '/mnt/host/etc/os-release';
+const MNT_OS_PATH_CANDIDATES = [
+  '/mnt/host/etc/os-release',
+  '/mnt/host/usr/lib/os-release',
+];
 
 export const setupOsVersion = async () => {
   try {
-    if (CONFIG.running_in_docker && fs.existsSync(MNT_OS_PATH)) {
-      for (const LOCAL_OS_PATH of LOCAL_OS_PATHS) {
-        if (fs.existsSync(LOCAL_OS_PATH)) {
-          await exec(`ln -sf ${MNT_OS_PATH} ${LOCAL_OS_PATH}`);
-        }
-      }
+    if (CONFIG.running_in_docker) {
+      const hostPath = MNT_OS_PATH_CANDIDATES.find(p => fs.existsSync(p));
 
-      console.log(`Using host os version from "${MNT_OS_PATH}"`);
-    } else {
-      console.log(
-        `Using host os version from ${LOCAL_OS_PATHS.map(p => `"${p}"`).join(
-          ' and '
-        )}`
-      );
+      if (hostPath) {
+        await refreshHostOsRelease();
+
+        const realFile = await resolveSymlink(hostPath);
+        const arrow = hostPath === realFile ? '' : ` → "${realFile}"`;
+
+        console.log(`Using host os-release from "${hostPath}"${arrow}`);
+        return;
+      }
     }
+
+    console.log(
+      `Using os-release from ${LOCAL_OS_PATHS
+        .filter(p => fs.existsSync(p))
+        .map(p => `"${p}"`)
+        .join(' or ')}`
+    );
   } catch (e) {
     console.warn(e);
   }

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -95,7 +95,9 @@ const MNT_OS_PATH_CANDIDATES = [
 export const setupOsVersion = async () => {
   try {
     if (CONFIG.running_in_docker) {
+      console.debug("CONFIG.running_in_docker", CONFIG.running_in_docker)
       const hostPath = MNT_OS_PATH_CANDIDATES.find(p => fs.existsSync(p));
+      console.debug("hostPath", hostPath)
 
       if (hostPath) {
         await refreshHostOsRelease();

--- a/apps/server/src/setup.ts
+++ b/apps/server/src/setup.ts
@@ -102,10 +102,11 @@ export const setupOsVersion = async () => {
       if (hostPath) {
         await refreshHostOsRelease();
 
-        const realFile = await resolveSymlink(hostPath);
-        const arrow = hostPath === realFile ? '' : ` → "${realFile}"`;
+        // const realFile = await resolveSymlink(hostPath);
+        // const arrow = hostPath === realFile ? '' : ` → "${realFile}"`;
 
-        console.log(`Using host os-release from "${hostPath}"${arrow}`);
+        console.log(`Using host os-release from "${hostPath}"`);
+        // console.log(`Using host os-release from "${hostPath}"${arrow}`);
         return;
       }
     }
@@ -118,6 +119,12 @@ export const setupOsVersion = async () => {
     );
   } catch (e) {
     console.warn(e);
+    console.log(
+      `Using host os-release from ${LOCAL_OS_PATHS
+        .filter(p => fs.existsSync(p))
+        .map(p => `"${p}"`)
+        .join(' or ')}`
+    );
   }
 };
 

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -28,7 +28,6 @@ export const resolveSymlink = async (
   maxDepth = 32,
 ): Promise<string> => {
   p = path.resolve(p);
-  console.debug("p", p)
 
   if (seen.has(p)) {
     throw new Error(`Symlink loop detected at ${p}`);
@@ -37,12 +36,10 @@ export const resolveSymlink = async (
     throw new Error(`Symlink chain longer than ${maxDepth}: ${[...seen, p].join(' → ')}`);
   }
   seen.add(p);
-  console.debug("seen", seen)
 
   let stat: fs.Stats;
   try {
     stat = await lstat(p);
-    console.debug("stat", stat)
   } catch (err) {
     const parts: string[] = [];
     let probe = p;
@@ -68,18 +65,15 @@ export const resolveSymlink = async (
   }
 
   if (!stat.isSymbolicLink()) {
-    console.debug("stat is not a symbolic link")
     return p;
   }
 
   let target = await readlink(p);
   if (!path.isAbsolute(target)) {
-    console.debug("relative target", target)
     target = path.resolve(path.dirname(p), target);
   }
 
   target = fromHost(target);
-  console.debug("target", target)
 
   return resolveSymlink(target, seen, maxDepth);
 }
@@ -97,11 +91,9 @@ export const refreshHostOsRelease = async(): Promise<void> => {
   if (!hostPath) return;
 
   const realFile = await resolveSymlink(hostPath);
-  console.debug("realFile", realFile)
 
   for (const local of LOCAL_OS_PATHS) {
     if (fs.existsSync(local)) {
-      console.debug("local", local)
       // Recurse in case os-release is a directory for some reason
       await rm(local, { recursive: true, force: true });
       await symlink(realFile, local, 'file');

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -1,6 +1,8 @@
 import os from 'os';
-import { join } from 'path';
+import path, { join } from 'path';
 import { CONFIG } from './config';
+import * as fs from 'fs';
+import { lstat, readlink, rm, symlink } from 'fs/promises';
 
 export const fromHost = (path: string): string => {
   const pathInDocker = path === '/' ? '/mnt/host' : join('/mnt/host', path);
@@ -8,3 +10,70 @@ export const fromHost = (path: string): string => {
 };
 
 export const PLATFORM_IS_WINDOWS = os.platform() === 'win32';
+
+/**
+ * Recursively resolve `p`.
+ *  - Rewrites absolute hops so they stay inside HOST_PREFIX.
+ *  - Detects loops.
+ *  - Stops after hitting a real file or exceeding `maxDepth`.
+ *
+ * @throws {Error} if a loop is detected or the chain is too deep.
+ */
+export const resolveSymlink = async (
+  p: string,
+  seen = new Set<string>(),
+  maxDepth = 32,
+): Promise<string> => {
+  p = path.resolve(p);
+
+  if (seen.has(p)) {
+    throw new Error(`Symlink loop detected at ${p}`);
+  }
+  if (seen.size >= maxDepth) {
+    throw new Error(`Symlink chain longer than ${maxDepth}: ${[...seen, p].join(' → ')}`);
+  }
+  seen.add(p);
+
+  let stat: fs.Stats;
+  try {
+    stat = await lstat(p);
+  } catch (err) {
+    throw new Error(`lstat failed for ${p}: ${(err as Error).message}`);
+  }
+
+  if (!stat.isSymbolicLink()) {
+    return p;
+  }
+
+  let target = await readlink(p);
+  if (!path.isAbsolute(target)) {
+    target = path.resolve(path.dirname(p), target);
+  }
+
+  target = fromHost(target);
+
+  return resolveSymlink(target, seen, maxDepth);
+}
+
+const LOCAL_OS_PATHS = ['/etc/os-release', '/usr/lib/os-release'];
+const HOST_OS_CANDIDATES = [
+  '/mnt/host/etc/os-release',
+  '/mnt/host/usr/lib/os-release',
+];
+
+export const refreshHostOsRelease = async(): Promise<void> => {
+  if (!CONFIG.running_in_docker) return;
+
+  const hostPath = HOST_OS_CANDIDATES.find(p => fs.existsSync(p));
+  if (!hostPath) return;
+
+  const realFile = await resolveSymlink(hostPath);
+
+  for (const local of LOCAL_OS_PATHS) {
+    if (fs.existsSync(local)) {
+      // Recurse in case os-release is a directory for some reason
+      await rm(local, { recursive: true, force: true });
+      await symlink(realFile, local, 'file');
+    }
+  }
+}

--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -73,7 +73,7 @@ const HOST_OS_CANDIDATES = [
 export const refreshHostOsRelease = async(): Promise<void> => {
   if (!CONFIG.running_in_docker) return;
 
-  const hostPath = HOST_OS_CANDIDATES.find(p => fs.existsSync(p));
+  const hostPath = HOST_OS_CANDIDATES.find(p => fs.lstatSync(p));
   if (!hostPath) return;
 
   const realFile = await resolveSymlink(hostPath);


### PR DESCRIPTION
**Description**

This PR follows absolute symlinks recursively in order to properly display `os-release`, even in environments such as NixOS which use absolute symlinks for `/etc/os-release`.

It also checks manually for `/mnt/host/etc/os-release` and `/mnt/host/usr/lib/os-release` in case a distro did not create `/etc/os-release` as a link at all to `/usr/lib/os-release`.

**Related Issue(s)**

#1232 
