### PR TITLE
fix: incorrect frontend assets path when using ROUTING_PATH

### DIFF
--- a/apps/view/project.json
+++ b/apps/view/project.json
@@ -10,7 +10,7 @@
       "defaultConfiguration": "production",
       "options": {
         "outputPath": "dist/apps/view",
-        "base": "/",
+        "base": "./",
         "sourcemap": true
       },
       "configurations": {


### PR DESCRIPTION
**Description**

When using the `ROUTING_PATH` config variable, the vite frontend assets couldn't be found. Changed the vite build options to use `./` for relative lookups.

Related to the recent release of 6.2.0, this is a hotfix PR to my previous PR #1229.