### PR TITLE
Dev

### DIFF
--- a/apps/server/src/utils.ts
+++ b/apps/server/src/utils.ts
@@ -14,6 +14,18 @@ export const fromHost = (path: string): string => {
 
 export const PLATFORM_IS_WINDOWS = os.platform() === 'win32';
 
+// Like existsSync but based on lstat so it also returns true for broken symlinks.
+// Returns false only when the path definitely does not exist (ENOENT/ENOTDIR).
+const lstatExists = (p: string): boolean => {
+  try {
+    fs.lstatSync(p);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return !(code === 'ENOENT' || code === 'ENOTDIR');
+  }
+}
+
 /**
  * Recursively resolve `p`.
  *  - Rewrites absolute hops so they stay inside HOST_PREFIX.
@@ -78,25 +90,49 @@ export const resolveSymlink = async (
   return resolveSymlink(target, seen, maxDepth);
 }
 
-const LOCAL_OS_PATHS = ['/etc/os-release', '/usr/lib/os-release'];
-const HOST_OS_CANDIDATES = [
-  '/mnt/host/etc/os-release',
-  '/mnt/host/usr/lib/os-release',
+const OS_CANDIDATES = [
+  '/etc/lsb-release', // Linux Standard Base distro info
+  '/etc/os-release', // Freedesktop OS metadata
+  '/usr/lib/os-release', // Fallback OS metadata location
+  '/etc/openwrt_release', // OpenWrt-specific release info
 ];
 
 export const refreshHostOsRelease = async(): Promise<void> => {
   if (!CONFIG.running_in_docker) return;
 
-  const hostPath = HOST_OS_CANDIDATES.find(p => fs.lstatSync(p));
-  if (!hostPath) return;
+  // At least one candidate must exist in the host
+  const hostPaths = OS_CANDIDATES.filter(p => lstatExists(fromHost(p)));
+  if (hostPaths.length === 0) return;
 
-  const realFile = await resolveSymlink(hostPath);
+  // Track the files that we can resolve from the host
+  const symlinkedLocals = new Set<string>();
 
-  for (const local of LOCAL_OS_PATHS) {
-    if (fs.existsSync(local)) {
-      // Recurse in case os-release is a directory for some reason
-      await rm(local, { recursive: true, force: true });
-      await symlink(realFile, local, 'file');
+  for (const local of hostPaths) {
+    try {
+      const realFile = await resolveSymlink(fromHost(local));
+
+      // Remove the local copy of the os-path even if there is no hostPath
+      await rm(local, { force: true });
+      if (fs.existsSync(realFile)) {
+        await symlink(realFile, local, 'file');
+        symlinkedLocals.add(local);
+      }
+    } catch (e) {
+      // Error resolving the symlink, warn
+      console.warn(e);
+    }
+  }
+
+  // If at least one symlink was created, remove any remaining candidate files that still exist as they do not represent the host, but the container
+  if (symlinkedLocals.size > 0) {
+    for (const candidate of OS_CANDIDATES) {
+      if (!symlinkedLocals.has(candidate) && lstatExists(candidate)) {
+        try {
+          await rm(candidate, { force: true });
+        } catch (e) {
+          console.warn(e);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
**Description**

Handle each possible OS file:

- `/etc/os-release`
- `/etc/lsb-release`
- `/etc/openwrt_release`
- `/usr/lib/os-release`

Follow broken links from the host (`/mnt/host`) and link them to the same file within the container.

In other words, `/mnt/host/etc/os-release` may link to something else, like `/mnt/host/nix/store/znmly1f5ahwz9yrl7h89ljqxyr0xrk94-etc-os-release` and the container establishes `/etc/os-release` to link to the same file by resolving the host links.

If at least one file from the host can be found and successfully linked, now the other candidate files from the container are cleaned up so that they do not incorrectly report the container's OS information.

I also improved the logging so you can see which candidate files were linked and which were not:

<img width="1253" height="486" alt="Screenshot 2025-08-15 at 7 31 33 PM" src="https://github.com/user-attachments/assets/c10df950-40b6-4c0f-8c9c-2fc8100702a9" />

In this case, my host uses both `/etc/os-release` and `/etc/lsb-release`, but neither of `/etc/openwrt_release` nor `/usr/lib/os-release`. As such:

```
dash-1  | OS metadata files:
dash-1  |   /etc/lsb-release -> "/mnt/host/nix/store/3zklxvjkwjb4ds0lf2jlcqcdggp1d272-etc-lsb-release"
dash-1  |   /etc/os-release -> "/mnt/host/nix/store/znmly1f5ahwz9yrl7h89ljqxyr0xrk94-etc-os-release"
dash-1  |   /usr/lib/os-release [missing]
dash-1  |   /etc/openwrt_release [missing]
```

**Related Issue(s)**

#1232 
